### PR TITLE
Update area island for consistency

### DIFF
--- a/Dynamic Islands/Dynamic Islands/Islands/Areas/AreasViews.swift
+++ b/Dynamic Islands/Dynamic Islands/Islands/Areas/AreasViews.swift
@@ -9,149 +9,106 @@ import SwiftUI
 import ActivityKit
 import WidgetKit
 
+// MARK: - Leading
+
 struct AreasCompactLeading: View {
     var body: some View {
         ZStack {
             Color.blue
             Text("Leading")
         }
-        
         // Smaller area with width modifier
-//        ZStack {
-//            Color.blue
-//            Text("Leading")
-//        }
 //        .frame(width: 24)
     }
 }
 
-struct AreasCompactLeading_Previews: PreviewProvider {
-    static var previews: some View {
-        AreasCompactTrailing()
+struct AreasLeading: View {
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Color.blue
+            Text("Leading")
+        }
+        .frame(width: 175, height: 60)
+        // If you want your view to reach the side of the dynamic island you can use a negative padding
+//        .padding(-20)
+    }
+}
+
+// MARK: - Trailing
+
+struct AreasTrailing: View {
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            Color.green
+            Text("Trailing")
+        }
+        .frame(width: 175, height: 60)
+        // If you want your view to reach the side of the dynamic island you can use a negative padding
+//        .padding(-20)
     }
 }
 
 struct AreasCompactTrailing: View {
     var body: some View {
-        Text("Trailing")
+        ZStack {
+            Color.green
+            Text("Trailing")
+        }
     }
 }
 
-struct AreasCompactTrailing_Previews: PreviewProvider {
-    static var previews: some View {
-        AreasCompactTrailing()
-    }
-}
+// MARK: - Minimal
 
 struct AreasMinimal: View {
     var body: some View {
-        Image(systemName: "alert")
-            .foregroundColor(.green)
-            .font(.title2)
+        ZStack {
+            Color.orange
+            Text("Min")
+        }
     }
 }
 
-struct AreasMinimal_Previews: PreviewProvider {
-    static var previews: some View {
-        AreasMinimal()
-    }
-}
+// MARK: - Center
 
-//MARK: LEADING
-struct AreasLeading: View {
-    var body: some View {
-        RoundedRectangle(cornerRadius: 20)
-//            .edgesIgnoringSafeArea(.all)
-            .frame(width: 200, height: 100)
-            .foregroundColor(.blue)
-        
-            // If you want your view to reach the side of the dynamic island you can use a negative padding
-            .padding(-20)
-        
-//        Circle()
-//            .edgesIgnoringSafeArea(.all)
-//            .frame(width: 200, height: 200)
-//            .foregroundColor(.purple)
-//
-//            // If you want your view to reach the side of the dynamic island you can use a negative padding
-//            .padding(-20)
-    }
-}
-
-struct AreasLeading_Previews: PreviewProvider {
-    static var previews: some View {
-        AreasLeading()
-    }
-}
-
-
-//MARK: TRAILING
-
-struct AreasTrailing: View {
-    var body: some View {
-        RoundedRectangle(cornerRadius: 20)
-//            .edgesIgnoringSafeArea(.all)
-            .frame(width: 200, height: 100)
-            .foregroundColor(.green)
-        
-            // If you want your view to reach the side of the dynamic island you can use a negative padding
-            .padding(-20)
-    }
-}
-
-struct AreasTrailing_Previews: PreviewProvider {
-    static var previews: some View {
-        AreasTrailing()
-    }
-}
-
-//MARK: CENTER
 struct AreasCenter: View {
     var body: some View {
-        RoundedRectangle(cornerRadius: 20)
-            .edgesIgnoringSafeArea(.all)
-            .frame(width: 200, height: 40)
-            .foregroundColor(.red)
-            .overlay(
-                    Text("Center")
-            )
+        ZStack {
+            RoundedRectangle(cornerRadius: 20)
+                .foregroundColor(.red)
+                .frame(width: 100, height: 28)
+            Text("Center")
+        }
     }
 }
 
-struct AreasCenter_Previews: PreviewProvider {
-    static var previews: some View {
-        AreasCenter()
-    }
-}
+// MARK: - Bottom
 
-//MARK: BOTTOM
 struct AreasBottom: View {
     var body: some View {
-        
-        RoundedRectangle(cornerRadius: 20)
-            .edgesIgnoringSafeArea(.all)
-            .frame(width: 300, height: 80)
-            .foregroundColor(.purple)
-            .overlay(
-                    Text("Bottom")
-            )
+        ZStack {
+            Color.purple
+            Text("Bottom")
+        }
+        .frame(width: 350, height: 60)
     }
 }
 
-struct AreasBottom_Previews: PreviewProvider {
-    static var previews: some View {
-        AreasBottom()
-    }
-}
-
-
+// MARK: - Lock screen live activity
 
 struct AreasLockScreen: View {
     let context: ActivityViewContext<AreasAttributes>
     
     var body: some View {
-        Text("This is the live activity")
+        VStack {
+            HStack {
+                AreasLeading()
+                Spacer()
+                AreasTrailing()
+            }
+            .overlay {
+                AreasCenter()
+            }
+            AreasBottom()
+        }
     }
 }
-
-

--- a/Dynamic Islands/Dynamic Islands/Islands/Areas/AreasWidget.swift
+++ b/Dynamic Islands/Dynamic Islands/Islands/Areas/AreasWidget.swift
@@ -18,15 +18,12 @@ struct AreasWidget: Widget {
                 DynamicIslandExpandedRegion(.leading, priority: 4) {
                     AreasLeading()
                 }
-
                 DynamicIslandExpandedRegion(.trailing) {
                     AreasTrailing()
                 }
-                
                 DynamicIslandExpandedRegion(.center) {
                     AreasCenter()
                 }
-            
                 DynamicIslandExpandedRegion(.bottom) {
                     AreasBottom()
                 }

--- a/Dynamic Islands/Dynamic Islands/Model/Island.swift
+++ b/Dynamic Islands/Dynamic Islands/Model/Island.swift
@@ -54,11 +54,10 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
                     .overlay(
                         Text("Areas")
                     )
-                    
 //                    .padding(.horizontal, 12)
                     .foregroundColor(.white)
                 )
-                .clipShape(RoundedRectangle(cornerRadius: 20))
+                .clipShape(RoundedRectangle(cornerRadius: 40))
                 .frame(height: 80)
         case .music:
             RoundedRectangle(cornerRadius: 40)


### PR DESCRIPTION
Small tweaks to `Area` island for consistency in layout (Lock Screen and expanded views, etc)

Before | After
--|--
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-15 at 18 50 29](https://user-images.githubusercontent.com/16542463/196001023-671343f5-14bf-4d91-a8e7-a18ce534e25b.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-15 at 18 47 13](https://user-images.githubusercontent.com/16542463/196001035-68f92579-a69d-4f68-8ac9-d7bb932484da.png)

Minimal | Compact
--|--
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-15 at 18 47 17](https://user-images.githubusercontent.com/16542463/196001103-cc8c7f47-8ff4-464c-ab18-e92973fda0b2.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-15 at 18 47 20](https://user-images.githubusercontent.com/16542463/196001110-bb4800b9-9fed-4eb5-b475-a19955a10c0c.png)

Expanded | Lock screen
--|--
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-15 at 18 47 22](https://user-images.githubusercontent.com/16542463/196001129-3aa386b7-4d02-4267-8fae-b42ccdf2302b.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-15 at 18 47 43](https://user-images.githubusercontent.com/16542463/196001135-937910af-7842-46a2-b301-ad866724d70d.png)
