### PR TITLE
Add support for dark mode

### DIFF
--- a/Dynamic Islands/Dynamic Islands/Model/Island.swift
+++ b/Dynamic Islands/Dynamic Islands/Model/Island.swift
@@ -24,20 +24,17 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
     var overviewView: some View {
         switch self {
         case .phone:
-            RoundedRectangle(cornerRadius: 40)
-                .foregroundColor(.black)
+            commonBackground
                 .overlay(
                     HStack {
                         PhoneLeading(caller: "Jordi Bruin")
                         Spacer()
                         PhoneTrailing()
                     }
-                    .padding(.horizontal, 12)
+                    .padding(.horizontal, 15)
                 )
-                .frame(height: 80)
         case .areas:
-            RoundedRectangle(cornerRadius: 40)
-                .foregroundColor(.black)
+            commonBackground
                 .overlay(
                     HStack(spacing: 0) {
                         Rectangle()
@@ -45,36 +42,30 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
                         Rectangle()
                             .foregroundColor(.green)
                     }
-                        
+                    .clipShape(Capsule())
+                    .padding(3)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 20)
+                        Capsule()
                             .foregroundColor(.red)
                             .frame(width: 100, height: 28)
+                            .overlay(
+                                Text("Areas")
+                                    .foregroundColor(.white)
+                            )
                     )
-                    .overlay(
-                        Text("Areas")
-                    )
-                    
-//                    .padding(.horizontal, 12)
-                    .foregroundColor(.white)
                 )
-                .clipShape(RoundedRectangle(cornerRadius: 20))
-                .frame(height: 80)
         case .music:
-            RoundedRectangle(cornerRadius: 40)
-                .foregroundColor(.black)
+            commonBackground
                 .overlay(
                     HStack {
                         MusicLeading()
                         Spacer()
                         MusicTrailing()
                     }
-                    .padding(.top, -4)
-                    .padding(.horizontal)
+                    .padding(.top, -7)
+                    .padding(.horizontal, 15)
                     .foregroundColor(.white)
                 )
-                .clipShape(RoundedRectangle(cornerRadius: 20))
-                .frame(height: 80)
         }
     }
     
@@ -110,6 +101,17 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
         case .music:
             return true
         }
+    }
+
+    private var commonBackground: some View {
+        Capsule()
+            .foregroundColor(.white.opacity(0.18))
+            .frame(height: 86)
+            .overlay(
+                Capsule()
+                    .foregroundColor(.black)
+                    .padding(3)
+            )
     }
 }
 

--- a/Dynamic Islands/Dynamic Islands/Model/Island.swift
+++ b/Dynamic Islands/Dynamic Islands/Model/Island.swift
@@ -31,7 +31,8 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
                         Spacer()
                         PhoneTrailing()
                     }
-                    .padding(.horizontal, 15)
+                    .padding(.horizontal, 12)
+                    .padding(2)
                 )
         case .areas:
             commonBackground
@@ -43,7 +44,6 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
                             .foregroundColor(.green)
                     }
                     .clipShape(Capsule())
-                    .padding(3)
                     .overlay(
                         Capsule()
                             .foregroundColor(.red)
@@ -53,6 +53,7 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
                                     .foregroundColor(.white)
                             )
                     )
+                    .padding(2)
                 )
         case .music:
             commonBackground
@@ -62,9 +63,10 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
                         Spacer()
                         MusicTrailing()
                     }
-                    .padding(.top, -7)
-                    .padding(.horizontal, 15)
+                    .padding(.top, -4)
+                    .padding(.horizontal, 12)
                     .foregroundColor(.white)
+                    .padding(2)
                 )
         }
     }
@@ -106,11 +108,11 @@ enum Island: String, CaseIterable, Identifiable, Hashable, Codable {
     private var commonBackground: some View {
         Capsule()
             .foregroundColor(.white.opacity(0.18))
-            .frame(height: 86)
+            .frame(height: 84)
             .overlay(
                 Capsule()
                     .foregroundColor(.black)
-                    .padding(3)
+                    .padding(2)
             )
     }
 }


### PR DESCRIPTION
Reference (Apple add a border around the island when the background is too dark):

<img src="https://user-images.githubusercontent.com/16542463/196042321-9909abe0-d51a-44e4-ae0a-8c8e1e289311.jpeg" width="375">

Before | After
--|--
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-16 at 15 45 04](https://user-images.githubusercontent.com/16542463/196042340-c8a6529e-714d-4d11-be11-fe3c090b4291.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-16 at 15 51 46](https://user-images.githubusercontent.com/16542463/196042348-ecb4184f-8f1c-42c7-81fc-a1c8d7a7f821.png)